### PR TITLE
Use resource detectors to populate resource

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pytest-cov==3.0.0
 capturer==3.0
 attrs==21.4.0
 requests==2.27.1
+responses==0.21.0
 moto==3.1.5
 click==8.0.3
 itsdangerous==2.0.1

--- a/src/lumigo_opentelemetry/resources/detectors/__init__.py
+++ b/src/lumigo_opentelemetry/resources/detectors/__init__.py
@@ -14,6 +14,7 @@ AWS_ECS_TASK_ARN = ResourceAttributes.AWS_ECS_TASK_ARN
 AWS_ECS_TASK_FAMILY = ResourceAttributes.AWS_ECS_TASK_FAMILY
 AWS_ECS_TASK_REVISION = ResourceAttributes.AWS_ECS_TASK_REVISION
 
+LUMIGO_DISTRO_VERSION_ATTR_NAME = 'lumigo.distro.version'
 
 _aws_ecs_detector_logger = getLogger('AwsEcsResourceDetector')
 
@@ -87,5 +88,18 @@ class ProcessResourceDetector(ResourceDetector):
                 PROCESS_RUNTIME_DESCRIPTION: sys.version,
                 PROCESS_RUNTIME_NAME: sys.implementation.name,
                 PROCESS_RUNTIME_VERSION: _runtime_version,
+            }
+        )
+
+class LumigoDistroDetector(ResourceDetector):
+    """Implementation of the detector for `process.*` attributes.
+    """
+
+    # pylint: disable=no-self-use
+    def detect(self) -> "Resource":
+        import lumigo_opentelemetry
+        return Resource(
+            {
+                LUMIGO_DISTRO_VERSION_ATTR_NAME: lumigo_opentelemetry.__version__,
             }
         )

--- a/src/lumigo_opentelemetry/resources/detectors/__init__.py
+++ b/src/lumigo_opentelemetry/resources/detectors/__init__.py
@@ -14,6 +14,10 @@ AWS_ECS_TASK_ARN = ResourceAttributes.AWS_ECS_TASK_ARN
 AWS_ECS_TASK_FAMILY = ResourceAttributes.AWS_ECS_TASK_FAMILY
 AWS_ECS_TASK_REVISION = ResourceAttributes.AWS_ECS_TASK_REVISION
 
+
+_aws_ecs_detector_logger = getLogger('AwsEcsResourceDetector')
+
+
 class AwsEcsResourceDetector(ResourceDetector):
     """Implements the lookup of the `aws.ecs` resource attributes using the Metadata v4 endpoint."""
 
@@ -57,7 +61,7 @@ class AwsEcsResourceDetector(ResourceDetector):
                 }
             )
         except Exception as e:
-            getLogger(self.__class__.__name__).error("An error occurred while looking up the AWS ECS resource attributes", e)
+            _aws_ecs_detector_logger.error("An error occurred while looking up the AWS ECS resource attributes: %s", e)
 
             return Resource.get_empty()
 

--- a/src/lumigo_opentelemetry/resources/detectors/__init__.py
+++ b/src/lumigo_opentelemetry/resources/detectors/__init__.py
@@ -1,0 +1,87 @@
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.sdk.resources import *;
+
+from logging import getLogger
+
+import os
+import requests
+import sys
+
+AWS_ECS_CLUSTER_ARN = ResourceAttributes.AWS_ECS_CLUSTER_ARN
+AWS_ECS_CONTAINER_ARN = ResourceAttributes.AWS_ECS_CONTAINER_ARN
+AWS_ECS_LAUNCHTYPE = ResourceAttributes.AWS_ECS_LAUNCHTYPE
+AWS_ECS_TASK_ARN = ResourceAttributes.AWS_ECS_TASK_ARN
+AWS_ECS_TASK_FAMILY = ResourceAttributes.AWS_ECS_TASK_FAMILY
+AWS_ECS_TASK_REVISION = ResourceAttributes.AWS_ECS_TASK_REVISION
+
+class AwsEcsResourceDetector(ResourceDetector):
+    """Implements the lookup of the `aws.ecs` resource attributes using the Metadata v4 endpoint."""
+
+    # pylint: disable=no-self-use
+    def detect(self) -> "Resource":
+        metadataEndpoint = os.environ.get('ECS_CONTAINER_METADATA_URI_V4')
+
+        if not metadataEndpoint:
+            return Resource.get_empty()
+
+        try:
+            # Returns https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html#task-metadata-endpoint-v4-response
+            metadataContainerResponse = requests.get(metadataEndpoint, timeout=1)
+            metadataContainerResponse.raise_for_status()
+            metadataContainer = metadataContainerResponse.json()
+
+            metadataTaskResponse = requests.get(f"{metadataEndpoint}/task", timeout=1)
+            metadataTaskResponse.raise_for_status()
+            metadataTask = metadataTaskResponse.json()
+
+            taskArn = metadataTask['TaskARN']
+            baseArn = taskArn[0: taskArn.rindex(':')]
+
+            cluster = metadataTask['Cluster']
+
+            try:
+                if cluster.index('arn:') == 0:
+                    clusterArn = cluster
+            except ValueError:
+                # Cluster is the shortname
+                clusterArn = f"{baseArn}:cluster/{cluster}"
+
+            return Resource(
+                {
+                    AWS_ECS_CLUSTER_ARN: clusterArn,
+                    AWS_ECS_CONTAINER_ARN: metadataContainer['ContainerARN'],
+                    AWS_ECS_LAUNCHTYPE: metadataTask['LaunchType'],
+                    AWS_ECS_TASK_ARN: taskArn,
+                    AWS_ECS_TASK_FAMILY: metadataTask['Family'],
+                    AWS_ECS_TASK_REVISION: metadataTask['Revision'],
+                }
+            )
+        except Exception as e:
+            getLogger(self.__class__.__name__).error("An error occurred while looking up the AWS ECS resource attributes", e)
+
+            return Resource.get_empty()
+
+"""TODO: Switch over to https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py on SDK upgrade"""
+class ProcessResourceDetector(ResourceDetector):
+    """Implementation of the detector for `process.*` attributes.
+    """
+
+    # pylint: disable=no-self-use
+    def detect(self) -> "Resource":
+        _runtime_version = ".".join(
+            map(
+                str,
+                sys.version_info[:3]
+                if sys.version_info.releaselevel == "final"
+                and not sys.version_info.serial
+                else sys.version_info,
+            )
+        )
+
+        return Resource(
+            {
+                PROCESS_RUNTIME_DESCRIPTION: sys.version,
+                PROCESS_RUNTIME_NAME: sys.implementation.name,
+                PROCESS_RUNTIME_VERSION: _runtime_version,
+            }
+        )

--- a/src/test/test_utils/spans_parser.py
+++ b/src/test/test_utils/spans_parser.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import List, Dict, Any, Optional
 
 
-SPANS_FILE_FULL_PATH = os.environ["LUMIGO_DEBUG_SPANDUMP"]
+SPANS_FILE_FULL_PATH = os.environ.get("LUMIGO_DEBUG_SPANDUMP")
 
 
 class SpansCounter:

--- a/src/test/unit/resources/detectors/metadatav4-response-container.json
+++ b/src/test/unit/resources/detectors/metadatav4-response-container.json
@@ -1,0 +1,44 @@
+{
+    "DockerId": "ea32192c8553fbff06c9340478a2ff089b2bb5646fb718b4ee206641c9086d66",
+    "Name": "curl",
+    "DockerName": "ecs-curltest-24-curl-cca48e8dcadd97805600",
+    "Image": "111122223333.dkr.ecr.us-west-2.amazonaws.com/curltest:latest",
+    "ImageID": "sha256:d691691e9652791a60114e67b365688d20d19940dde7c4736ea30e660d8d3553",
+    "Labels": {
+        "com.amazonaws.ecs.cluster": "default",
+        "com.amazonaws.ecs.container-name": "curl",
+        "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/8f03e41243824aea923aca126495f665",
+        "com.amazonaws.ecs.task-definition-family": "curltest",
+        "com.amazonaws.ecs.task-definition-version": "24"
+    },
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "Limits": {
+        "CPU": 10,
+        "Memory": 128
+    },
+    "CreatedAt": "2020-10-02T00:15:07.620912337Z",
+    "StartedAt": "2020-10-02T00:15:08.062559351Z",
+    "Type": "NORMAL",
+    "LogDriver": "awslogs",
+    "LogOptions": {
+        "awslogs-create-group": "true",
+        "awslogs-group": "/ecs/metadata",
+        "awslogs-region": "us-west-2",
+        "awslogs-stream": "ecs/curl/8f03e41243824aea923aca126495f665"
+    },
+    "ContainerARN": "arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9",
+    "Networks": [
+        {
+            "NetworkMode": "awsvpc",
+            "IPv4Addresses": [
+                "10.0.2.100"
+            ],
+            "AttachmentIndex": 0,
+            "MACAddress": "0e:9e:32:c7:48:85",
+            "IPv4SubnetCIDRBlock": "10.0.2.0/24",
+            "PrivateDNSName": "ip-10-0-2-100.us-west-2.compute.internal",
+            "SubnetGatewayIpv4Address": "10.0.2.1/24"
+        }
+    ]
+}

--- a/src/test/unit/resources/detectors/metadatav4-response-task.json
+++ b/src/test/unit/resources/detectors/metadatav4-response-task.json
@@ -1,0 +1,94 @@
+{
+    "Cluster": "default",
+    "TaskARN": "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
+    "Family": "curltest",
+    "Revision": "26",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "PullStartedAt": "2020-10-02T00:43:06.202617438Z",
+    "PullStoppedAt": "2020-10-02T00:43:06.31288465Z",
+    "AvailabilityZone": "us-west-2d",
+    "LaunchType": "EC2",
+    "Containers": [
+        {
+            "DockerId": "598cba581fe3f939459eaba1e071d5c93bb2c49b7d1ba7db6bb19deeb70d8e38",
+            "Name": "~internal~ecs~pause",
+            "DockerName": "ecs-curltest-26-internalecspause-e292d586b6f9dade4a00",
+            "Image": "amazon/amazon-ecs-pause:0.1.0",
+            "ImageID": "",
+            "Labels": {
+                "com.amazonaws.ecs.cluster": "default",
+                "com.amazonaws.ecs.container-name": "~internal~ecs~pause",
+                "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
+                "com.amazonaws.ecs.task-definition-family": "curltest",
+                "com.amazonaws.ecs.task-definition-version": "26"
+            },
+            "DesiredStatus": "RESOURCES_PROVISIONED",
+            "KnownStatus": "RESOURCES_PROVISIONED",
+            "Limits": {
+                "CPU": 0,
+                "Memory": 0
+            },
+            "CreatedAt": "2020-10-02T00:43:05.602352471Z",
+            "StartedAt": "2020-10-02T00:43:06.076707576Z",
+            "Type": "CNI_PAUSE",
+            "Networks": [
+                {
+                    "NetworkMode": "awsvpc",
+                    "IPv4Addresses": [
+                        "10.0.2.61"
+                    ],
+                    "AttachmentIndex": 0,
+                    "MACAddress": "0e:10:e2:01:bd:91",
+                    "IPv4SubnetCIDRBlock": "10.0.2.0/24",
+                    "PrivateDNSName": "ip-10-0-2-61.us-west-2.compute.internal",
+                    "SubnetGatewayIpv4Address": "10.0.2.1/24"
+                }
+            ]
+        },
+        {
+            "DockerId": "ee08638adaaf009d78c248913f629e38299471d45fe7dc944d1039077e3424ca",
+            "Name": "curl",
+            "DockerName": "ecs-curltest-26-curl-a0e7dba5aca6d8cb2e00",
+            "Image": "111122223333.dkr.ecr.us-west-2.amazonaws.com/curltest:latest",
+            "ImageID": "sha256:d691691e9652791a60114e67b365688d20d19940dde7c4736ea30e660d8d3553",
+            "Labels": {
+                "com.amazonaws.ecs.cluster": "default",
+                "com.amazonaws.ecs.container-name": "curl",
+                "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
+                "com.amazonaws.ecs.task-definition-family": "curltest",
+                "com.amazonaws.ecs.task-definition-version": "26"
+            },
+            "DesiredStatus": "RUNNING",
+            "KnownStatus": "RUNNING",
+            "Limits": {
+                "CPU": 10,
+                "Memory": 128
+            },
+            "CreatedAt": "2020-10-02T00:43:06.326590752Z",
+            "StartedAt": "2020-10-02T00:43:06.767535449Z",
+            "Type": "NORMAL",
+            "LogDriver": "awslogs",
+            "LogOptions": {
+                "awslogs-create-group": "true",
+                "awslogs-group": "/ecs/metadata",
+                "awslogs-region": "us-west-2",
+                "awslogs-stream": "ecs/curl/158d1c8083dd49d6b527399fd6414f5c"
+            },
+            "ContainerARN": "arn:aws:ecs:us-west-2:111122223333:container/abb51bdd-11b4-467f-8f6c-adcfe1fe059d",
+            "Networks": [
+                {
+                    "NetworkMode": "awsvpc",
+                    "IPv4Addresses": [
+                        "10.0.2.61"
+                    ],
+                    "AttachmentIndex": 0,
+                    "MACAddress": "0e:10:e2:01:bd:91",
+                    "IPv4SubnetCIDRBlock": "10.0.2.0/24",
+                    "PrivateDNSName": "ip-10-0-2-61.us-west-2.compute.internal",
+                    "SubnetGatewayIpv4Address": "10.0.2.1/24"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/unit/resources/detectors/test_aws_ecs_detector.py
+++ b/src/test/unit/resources/detectors/test_aws_ecs_detector.py
@@ -1,0 +1,48 @@
+import json
+import os
+import responses
+from unittest import mock
+
+from lumigo_opentelemetry.resources.detectors import AwsEcsResourceDetector
+
+_AWS_ECS_METADATA_URL='http://test.uri.ecs'
+
+def load_json(filename):
+    with open(os.path.join(os.path.dirname(__file__), filename)) as file:
+        return json.loads(file.read())
+    
+
+_metadata_container_response = load_json('metadatav4-response-container.json')
+_metadata_task_response = load_json('metadatav4-response-task.json')
+
+
+@responses.activate
+def test_happy_path():
+    responses.add(
+        method="GET",
+        url=_AWS_ECS_METADATA_URL,
+        json=_metadata_container_response
+    )
+
+    responses.add(
+        method="GET",
+        url=f"{_AWS_ECS_METADATA_URL}/task",
+        json=_metadata_task_response
+    )
+
+    with mock.patch.dict(os.environ, {"ECS_CONTAINER_METADATA_URI_V4": _AWS_ECS_METADATA_URL}):
+        resource = AwsEcsResourceDetector().detect()
+
+    assert resource.attributes['aws.ecs.container.arn'] == 'arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9'
+    assert resource.attributes['aws.ecs.cluster.arn'] == 'arn:aws:ecs:us-west-2:111122223333:cluster/default'
+    assert resource.attributes['aws.ecs.launchtype'] == 'EC2'
+    assert resource.attributes['aws.ecs.task.arn'] == 'arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c'
+    assert resource.attributes['aws.ecs.task.family'] == 'curltest'
+    assert resource.attributes['aws.ecs.task.revision'] == '26'
+
+@responses.activate
+def test_timeout():
+    pass
+
+def test_no_ecs():
+    assert not AwsEcsResourceDetector().detect().attributes

--- a/src/test/unit/resources/detectors/test_aws_ecs_detector.py
+++ b/src/test/unit/resources/detectors/test_aws_ecs_detector.py
@@ -1,9 +1,10 @@
 import json
 import os
+import requests
 import responses
-from unittest import mock
+import lumigo_opentelemetry.resources.detectors as detectors
 
-from lumigo_opentelemetry.resources.detectors import AwsEcsResourceDetector
+from unittest.mock import patch, MagicMock
 
 _AWS_ECS_METADATA_URL='http://test.uri.ecs'
 
@@ -30,8 +31,8 @@ def test_happy_path():
         json=_metadata_task_response
     )
 
-    with mock.patch.dict(os.environ, {"ECS_CONTAINER_METADATA_URI_V4": _AWS_ECS_METADATA_URL}):
-        resource = AwsEcsResourceDetector().detect()
+    with patch.dict(os.environ, {"ECS_CONTAINER_METADATA_URI_V4": _AWS_ECS_METADATA_URL}):
+        resource = detectors.AwsEcsResourceDetector().detect()
 
     assert resource.attributes['aws.ecs.container.arn'] == 'arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9'
     assert resource.attributes['aws.ecs.cluster.arn'] == 'arn:aws:ecs:us-west-2:111122223333:cluster/default'
@@ -40,9 +41,16 @@ def test_happy_path():
     assert resource.attributes['aws.ecs.task.family'] == 'curltest'
     assert resource.attributes['aws.ecs.task.revision'] == '26'
 
-@responses.activate
 def test_timeout():
-    pass
+    timeout_error = requests.exceptions.Timeout()
+
+    with patch.object(detectors._aws_ecs_detector_logger, 'error', MagicMock()):
+        with patch.object(requests, 'get', side_effect=timeout_error):
+            with patch.dict(os.environ, {'ECS_CONTAINER_METADATA_URI_V4': _AWS_ECS_METADATA_URL}):
+                resource = detectors.AwsEcsResourceDetector().detect()
+
+                assert not resource.attributes
+                detectors._aws_ecs_detector_logger.error.assert_called_once_with("An error occurred while looking up the AWS ECS resource attributes: %s", timeout_error)
 
 def test_no_ecs():
-    assert not AwsEcsResourceDetector().detect().attributes
+    assert not detectors.AwsEcsResourceDetector().detect().attributes

--- a/src/test/unit/resources/detectors/test_lumigo_detector.py
+++ b/src/test/unit/resources/detectors/test_lumigo_detector.py
@@ -1,0 +1,6 @@
+import lumigo_opentelemetry.resources.detectors as detectors
+
+def test_lumigo_distro_version():
+    resource = detectors.LumigoDistroDetector().detect()
+    assert 'lumigo.distro.version' in resource.attributes
+    assert resource.attributes['lumigo.distro.version']


### PR DESCRIPTION
Wire up the OTELResourceDetector and ProcessResourceDetector, and introduce a new AwsEcsResourceDetector (to be upstreamed) implemented according to the Otel Semantic Conventions specs.