### PR TITLE
run component tests only on minor versions

### DIFF
--- a/.github/workflows/nightly-actions.yml
+++ b/.github/workflows/nightly-actions.yml
@@ -1,7 +1,7 @@
 name: Version Testing
-on: [push]
-#  schedule:
-#    - cron: "0 0 * * *"
+on:
+  schedule:
+    - cron: "0 0 * * *"
 jobs:
   check-new-versions-of-instrumented-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-actions.yml
+++ b/.github/workflows/nightly-actions.yml
@@ -1,17 +1,20 @@
 name: Version Testing
-on:
-  schedule:
-    - cron: "0 0 * * *"
+on: [push]
+#  schedule:
+#    - cron: "0 0 * * *"
 jobs:
   check-new-versions-of-instrumented-packages:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     name: check-new-verisons-of-instrumented-packages
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: sudo apt update && sudo apt install -y libxml-xpath-perl git
       - run: git config user.email "versionbot@lumigo.io" && git config user.name "Version Bot"
@@ -24,4 +27,4 @@ jobs:
       - run: python3 -m nox
         env:
           TEST_PATCH_VERSIONS: true
-      - run: git push origin
+#      - run: git push origin

--- a/.github/workflows/nightly-actions.yml
+++ b/.github/workflows/nightly-actions.yml
@@ -22,4 +22,6 @@ jobs:
       - run: pip3 install nox
       - run: pip3 install psutil
       - run: python3 -m nox
+        env:
+          TEST_PATCH_VERSIONS: true
       - run: git push origin

--- a/.github/workflows/push-actions.yml
+++ b/.github/workflows/push-actions.yml
@@ -17,3 +17,5 @@ jobs:
       - run: pip3 install nox
       - run: pip3 install psutil
       - run: python3 -m nox
+        env:
+          TEST_PATCH_VERSIONS: true

--- a/.github/workflows/push-actions.yml
+++ b/.github/workflows/push-actions.yml
@@ -17,5 +17,3 @@ jobs:
       - run: pip3 install nox
       - run: pip3 install psutil
       - run: python3 -m nox
-        env:
-          TEST_PATCH_VERSIONS: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,13 +124,10 @@ def integration_tests_fastapi_fastapi(
     session,
     fastapi_version,
 ):
-    uvicorn_version = dependency_versions(
-        directory="fastapi", dependency_name="uvicorn"
-    )[0]
     integration_tests_fastapi(
         session=session,
         fastapi_version=fastapi_version,
-        uvicorn_version=uvicorn_version,
+        uvicorn_version="0.17.6",  # arbitrary version
     )
 
 
@@ -143,12 +140,9 @@ def integration_tests_fastapi_uvicorn(
     session,
     uvicorn_version,
 ):
-    fastapi_version = dependency_versions(
-        directory="fastapi", dependency_name="fastapi"
-    )[0]
     integration_tests_fastapi(
         session=session,
-        fastapi_version=fastapi_version,
+        fastapi_version="0.78.0",  # arbitrary version
         uvicorn_version=uvicorn_version,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,13 +108,42 @@ def integration_tests_boto3(
 
 @nox.session(python=python_versions())
 @nox.parametrize(
-    "uvicorn_version",
-    dependency_versions(directory="fastapi", dependency_name="uvicorn"),
-)
-@nox.parametrize(
     "fastapi_version",
     dependency_versions(directory="fastapi", dependency_name="fastapi"),
 )
+def integration_tests_fastapi_fastapi(
+    session,
+    fastapi_version,
+):
+    uvicorn_version = dependency_versions(
+        directory="fastapi", dependency_name="uvicorn"
+    )[0]
+    integration_tests_fastapi(
+        session=session,
+        fastapi_version=fastapi_version,
+        uvicorn_version=uvicorn_version,
+    )
+
+
+@nox.session(python=python_versions())
+@nox.parametrize(
+    "uvicorn_version",
+    dependency_versions(directory="fastapi", dependency_name="uvicorn"),
+)
+def integration_tests_fastapi_uvicorn(
+    session,
+    uvicorn_version,
+):
+    fastapi_version = dependency_versions(
+        directory="fastapi", dependency_name="fastapi"
+    )[0]
+    integration_tests_fastapi(
+        session=session,
+        fastapi_version=fastapi_version,
+        uvicorn_version=uvicorn_version,
+    )
+
+
 def integration_tests_fastapi(
     session,
     fastapi_version,

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,11 +26,15 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
             + f"/src/test/integration/{directory}/tested_versions/{dependency_name}",
             "r",
         ) as f:
-            return [
+            all_versions = [
                 line.strip()
                 for line in f.readlines()
                 if line.strip()[0] != "!"  # We mark incompatible versions with '1'
             ]
+            minor_to_version = {
+                version[: version.find(".", 2)]: version for version in all_versions
+            }
+            return list(minor_to_version.values())
     except FileNotFoundError:
         return []
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,6 +33,7 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
                 if line.strip()[0] != "!"  # We mark incompatible versions with '1'
             ]
             if os.getenv("TEST_PATCH_VERSIONS", "").lower() == "true":
+                print("running all versions of:", dependency_name, all_versions)
                 return all_versions
             minor_to_version: Dict[str, Version] = {}
             for version in all_versions:
@@ -40,7 +41,9 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
                 minor = f"{parsed_version.major}.{parsed_version.minor}"
                 if minor_to_version.get(minor, parse_version("0")) < parsed_version:
                     minor_to_version[minor] = parsed_version
-            return [v.public for v in minor_to_version.values()]
+            minor_versions = [v.public for v in minor_to_version.values()]
+            print("running minor versions of:", dependency_name, minor_versions)
+            return minor_versions
     except FileNotFoundError:
         return []
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,13 @@ def python_versions() -> Union[List[str], bool]:
     return ["3.7", "3.8", "3.9", "3.10"]
 
 
-def dependency_versions(directory: str, dependency_name: str) -> List[str]:
+def should_run_patch() -> bool:
+    return os.getenv("TEST_PATCH_VERSIONS", "").lower() == "true"
+
+
+def dependency_versions(
+    directory: str, dependency_name: str, run_patch: bool
+) -> List[str]:
     """Dependenciy versions are listed in the 'tested_versions/<dependency_name>' files of the instrumentation
     packages, and symlinked under the relevant integration tests."""
     try:
@@ -32,7 +38,7 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
                 for line in f.readlines()
                 if line.strip()[0] != "!"  # We mark incompatible versions with '1'
             ]
-            if os.getenv("TEST_PATCH_VERSIONS", "").lower() == "true":
+            if run_patch:
                 print("running all versions of", dependency_name, all_versions)
                 return all_versions
             minor_to_version: Dict[str, Version] = {}
@@ -50,7 +56,10 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
 
 @nox.session(python=python_versions())
 @nox.parametrize(
-    "boto3_version", dependency_versions(directory="boto3", dependency_name="boto3")
+    "boto3_version",
+    dependency_versions(
+        directory="boto3", dependency_name="boto3", run_patch=should_run_patch()
+    ),
 )
 def integration_tests_boto3(
     session,
@@ -118,7 +127,11 @@ def integration_tests_boto3(
 @nox.session(python=python_versions())
 @nox.parametrize(
     "fastapi_version",
-    dependency_versions(directory="fastapi", dependency_name="fastapi"),
+    dependency_versions(
+        directory="fastapi",
+        dependency_name="fastapi",
+        run_patch=should_run_patch(),
+    ),
 )
 def integration_tests_fastapi_fastapi(
     session,
@@ -134,7 +147,11 @@ def integration_tests_fastapi_fastapi(
 @nox.session(python=python_versions())
 @nox.parametrize(
     "uvicorn_version",
-    dependency_versions(directory="fastapi", dependency_name="uvicorn"),
+    dependency_versions(
+        directory="fastapi",
+        dependency_name="uvicorn",
+        run_patch=should_run_patch(),
+    ),
 )
 def integration_tests_fastapi_uvicorn(
     session,
@@ -219,7 +236,10 @@ def integration_tests_fastapi(
 
 @nox.session(python=python_versions())
 @nox.parametrize(
-    "flask_version", dependency_versions(directory="flask", dependency_name="flask")
+    "flask_version",
+    dependency_versions(
+        directory="flask", dependency_name="flask", run_patch=should_run_patch()
+    ),
 )
 def integration_tests_flask(session, flask_version):
     try:
@@ -284,7 +304,11 @@ def integration_tests_flask(session, flask_version):
 @nox.session(python=python_versions())
 @nox.parametrize(
     "pymongo_version",
-    dependency_versions(directory="pymongo", dependency_name="pymongo"),
+    dependency_versions(
+        directory="pymongo",
+        dependency_name="pymongo",
+        run_patch=should_run_patch(),
+    ),
 )
 def integration_tests_pymongo(
     session,
@@ -352,7 +376,11 @@ def integration_tests_pymongo(
 @nox.session(python=python_versions())
 @nox.parametrize(
     "pymysql_version",
-    dependency_versions(directory="pymysql", dependency_name="pymysql"),
+    dependency_versions(
+        directory="pymysql",
+        dependency_name="pymysql",
+        run_patch=should_run_patch(),
+    ),
 )
 def integration_tests_pymysql(
     session,

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
                 if line.strip()[0] != "!"  # We mark incompatible versions with '1'
             ]
             if os.getenv("TEST_PATCH_VERSIONS", "").lower() == "true":
-                print("running all versions of:", dependency_name, all_versions)
+                print("running all versions of", dependency_name, all_versions)
                 return all_versions
             minor_to_version: Dict[str, Version] = {}
             for version in all_versions:
@@ -42,7 +42,7 @@ def dependency_versions(directory: str, dependency_name: str) -> List[str]:
                 if minor_to_version.get(minor, parse_version("0")) < parsed_version:
                     minor_to_version[minor] = parsed_version
             minor_versions = [v.public for v in minor_to_version.values()]
-            print("running minor versions of:", dependency_name, minor_versions)
+            print("running minor versions of", dependency_name, minor_versions)
             return minor_versions
     except FileNotFoundError:
         return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ typing_extensions==4.0.1
 Werkzeug==2.0.2
 zipp==3.8.0
 nox==2022.1.7
-psutil==5.9.1 
+psutil==5.9.1
+packaging==21.3


### PR DESCRIPTION
- Push should run only for minor versions
- Disable fastapi*uvicorn
- Nightly should run on patch
- Nightly should run for each python-version