### PR TITLE
feat: export trace_processor to enable force_flush of spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,30 @@ If the ECS task uses the ECS agent v1.4.0, and has therefore access to the [Task
   * `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`
 
   ** If the `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable is not set, the span attribute size limit will be taken from `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable. The default size limit when both are not set is 2048.  
+
+## Advanced use cases
+
+### Access to the TracerProvider
+
+The Lumigo OpenTelemetry Distro provides access to the `TracerProvider` it configures (see the [Baseline setup](#baseline_setup) section for more information) through the `tracer_provider` attribute of the `lumigo_opentelemetry` package:
+
+```python
+from lumigo_opentelemetry import tracer_provider
+
+# Do here stuff like adding span processors
+```
+
+### Ensure spans are flushed to Lumigo before shutdown
+
+For short-running processes, the `BatchProcessor` configured by the Lumigo OpenTelemetry Distro may not ensure that the tracing data are sent to Lumigo (see the [Baseline setup](#baseline_setup) section for more information).
+Through the access to the `tracer_provider`, however, it is possible to ensure that all spans are flushed to Lumigo as follows:
+
+```python
+from lumigo_opentelemetry import tracer_provider
+
+# Do some logic
+
+tracer_provider.force_flush()
+
+# Now the Python process can terminate, with all the spans closed so far sent to Lumigo
+```

--- a/src/lumigo_opentelemetry/__init__.py
+++ b/src/lumigo_opentelemetry/__init__.py
@@ -63,12 +63,12 @@ def auto_load(_: Any) -> None:
     # to the init() call at the end of this file.
 
 
-def init() -> None:
+def init() -> Dict:
     if str(os.environ.get("LUMIGO_SWITCH_OFF", False)).lower() == "true":
         logger.info(
             "Lumigo OpenTelemetry distribution disabled via the 'LUMIGO_SWITCH_OFF' environment variable"
         )
-        return
+        return {}
 
     # Multiple packages are passed to autowrapt in comma-separated form
     if "lumigo_opentelemetry" in os.getenv("AUTOWRAPT_BOOTSTRAP", "").split(","):
@@ -143,6 +143,8 @@ def init() -> None:
 
     trace.set_tracer_provider(tracer_provider)
 
+    return {"tracer_provider": tracer_provider}
+
 
 def lumigo_wrapped(func: Callable[..., T]) -> Callable[..., T]:
     CONTEXT_NAME = "lumigo"
@@ -163,7 +165,9 @@ def lumigo_wrapped(func: Callable[..., T]) -> Callable[..., T]:
     return wrapper
 
 
-__all__ = ["auto_load", "init", "lumigo_wrapped", "logger"]
-
 # Load the package on import
-init()
+init_data = init()
+
+tracer_provider = init_data.get("tracer_provider")
+
+__all__ = ["auto_load", "init", "lumigo_wrapped", "logger", "tracer_provider"]

--- a/src/lumigo_opentelemetry/__init__.py
+++ b/src/lumigo_opentelemetry/__init__.py
@@ -63,7 +63,7 @@ def auto_load(_: Any) -> None:
     # to the init() call at the end of this file.
 
 
-def init() -> Dict:
+def init() -> Dict[str, Any]:
     if str(os.environ.get("LUMIGO_SWITCH_OFF", False)).lower() == "true":
         logger.info(
             "Lumigo OpenTelemetry distribution disabled via the 'LUMIGO_SWITCH_OFF' environment variable"

--- a/src/test/unit/test_tracer.py
+++ b/src/test/unit/test_tracer.py
@@ -1,0 +1,11 @@
+import unittest
+
+
+class TestDistroInit(unittest.TestCase):
+    def test_access_trace_provider(self):
+        from lumigo_opentelemetry import tracer_provider
+
+        self.assertIsNotNone(tracer_provider)
+
+        self.assertTrue(hasattr(tracer_provider, 'force_flush'))
+        self.assertTrue(hasattr(tracer_provider, 'shutdown'))

--- a/src/test/unit/test_tracer.py
+++ b/src/test/unit/test_tracer.py
@@ -7,5 +7,5 @@ class TestDistroInit(unittest.TestCase):
 
         self.assertIsNotNone(tracer_provider)
 
-        self.assertTrue(hasattr(tracer_provider, 'force_flush'))
-        self.assertTrue(hasattr(tracer_provider, 'shutdown'))
+        self.assertTrue(hasattr(tracer_provider, "force_flush"))
+        self.assertTrue(hasattr(tracer_provider, "shutdown"))


### PR DESCRIPTION
For use-cases with Python executing batch jobs, the BatchProcessor we set up is likely to lose root spans.

This change exposes the `tracer_provider` used by the distro, that can be imported by the instrumented application to ensure that spans are sent to Lumigo using the `TracerProvider.force_flush()` or `TracerProvider.shutdown()` methods.