### PR TITLE
Add support for span links in boto3 sqs span links

### DIFF
--- a/src/test/integration/boto3-sqs/app/main.py
+++ b/src/test/integration/boto3-sqs/app/main.py
@@ -21,6 +21,10 @@ def run():
         QueueUrl=queue["QueueUrl"],
         MessageBody="Message_2",
     )
+    client.send_message(
+        QueueUrl=queue["QueueUrl"],
+        MessageBody="Message_3",
+    )
 
     messages_copy = None
 
@@ -48,9 +52,9 @@ def run():
         ) as span:
             span.set_attribute("foo", "bar")
 
-    response = client.receive_message(QueueUrl=queue["QueueUrl"], MaxNumberOfMessages=1)
+    response = client.receive_message(QueueUrl=queue["QueueUrl"], MaxNumberOfMessages=2)
     if response:
-        for message in response["Messages"]:
+        for message in response.get("Messages", []):
             # In the iterator, we must restore the span for client.receive_message
             break  # Here we are supposed to lose the trace context
 

--- a/src/test/integration/boto3-sqs/tests/test_boto3_sqs.py
+++ b/src/test/integration/boto3-sqs/tests/test_boto3_sqs.py
@@ -6,18 +6,21 @@ from test.test_utils.spans_parser import SpansContainer
 class TestBoto3SqsSpans(unittest.TestCase):
     def test_boto3_instrumentation(self):
         spans_container = SpansContainer.parse_spans_from_file()
-        self.assertEqual(9, len(spans_container.spans))
+        self.assertEqual(12, len(spans_container.spans))
 
         [
             create_queue_span,
             send_message_1_span,
             send_message_2_span,
+            send_message_3_span,
             receive_message_1_span,
             # The unintuitive ordering of the unpacking is due to the fact
             # that the child nested at level 2 is ended first
             consume_message_2_span,
             consume_message_1_span,
             iterator_on_copy_span,
+            processing_message_2_span,
+            processing_message_3_span,
             receive_message_2_span,
             after_iterator_break_span,
         ] = spans_container.spans
@@ -30,6 +33,9 @@ class TestBoto3SqsSpans(unittest.TestCase):
 
         self.assertEqual(send_message_2_span["name"], "SQS.SendMessage")
         self.assertIsNone(send_message_2_span["parent_id"])
+
+        self.assertEqual(send_message_3_span["name"], "SQS.SendMessage")
+        self.assertIsNone(send_message_3_span["parent_id"])
 
         self.assertEqual(receive_message_1_span["name"], "SQS.ReceiveMessage")
         self.assertIsNone(receive_message_1_span["parent_id"])
@@ -66,6 +72,60 @@ class TestBoto3SqsSpans(unittest.TestCase):
         self.assertNotEquals(
             iterator_on_copy_span["context"]["trace_id"],
             receive_message_2_span["context"]["trace_id"],
+        )
+
+        self.assertTrue(processing_message_2_span["name"].startswith("Message "))
+        self.assertEqual(
+            processing_message_2_span["context"]["trace_id"],
+            receive_message_2_span["context"]["trace_id"],
+        )
+        self.assertEqual(
+            processing_message_2_span["parent_id"],
+            receive_message_2_span["context"]["span_id"],
+        )
+        self.assertListEqual(
+            processing_message_2_span["links"],
+            [
+                {
+                    "context": {
+                        "trace_id": send_message_2_span["context"]["trace_id"],
+                        "span_id": send_message_2_span["context"]["span_id"],
+                        "trace_state": "[]",
+                    },
+                    "attributes": {
+                        "messaging.message_id": send_message_2_span["attributes"][
+                            "messaging.message_id"
+                        ]
+                    },
+                }
+            ],
+        )
+
+        self.assertTrue(processing_message_3_span["name"].startswith("Message "))
+        self.assertEqual(
+            processing_message_3_span["context"]["trace_id"],
+            receive_message_2_span["context"]["trace_id"],
+        )
+        self.assertEqual(
+            processing_message_3_span["parent_id"],
+            receive_message_2_span["context"]["span_id"],
+        )
+        self.assertListEqual(
+            processing_message_3_span["links"],
+            [
+                {
+                    "context": {
+                        "trace_id": send_message_3_span["context"]["trace_id"],
+                        "span_id": send_message_3_span["context"]["span_id"],
+                        "trace_state": "[]",
+                    },
+                    "attributes": {
+                        "messaging.message_id": send_message_3_span["attributes"][
+                            "messaging.message_id"
+                        ]
+                    },
+                }
+            ],
         )
 
         self.assertEqual(after_iterator_break_span["name"], "after_iterator_break")


### PR DESCRIPTION
Create "message-processing" spans under the `SQS.ReceiveMessage` span, which contains a span link to the `SQS.SendMessage` or `SQS.SendMessageBatch` spans that represent the queuing of the messages.