### PR TITLE
fix: Pin typing_extensions version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,7 @@ setup(
         "opentelemetry-instrumentation-pymysql==0.36b0",
         "opentelemetry-instrumentation-requests==0.36b0",
         "opentelemetry-instrumentation-redis==0.36b0",
+        # v4.7.1 is the last version that supports python 3.7
+        "typing_extensions==4.7.1; python_version<'3.8'",
     ],
 )


### PR DESCRIPTION
v4.8.0 and newer versions of typing_extensions have dropped support for Python 3.7