### PR TITLE
chore: test new CI image with Python 3.11.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
 
     - lumigo-orb/prep-it-resources:
         context: common
+        docker_image: "lumigo/ci-ubuntu2204-node20:26.2.4-testing-add-python3.11.9-to-ci-image"
         requires:
           - lumigo-orb/is_environment_available
 
@@ -49,6 +50,7 @@ workflows:
 
     - lumigo-orb/integration-test-parallel:
         context: common
+        docker_image: "lumigo/ci-ubuntu2204-node20:26.2.4-testing-add-python3.11.9-to-ci-image"
         run_test_cleanup: false
         skip_on_auto_test_update: true
         requires:


### PR DESCRIPTION
## Summary

Testing the new CI image `lumigo/ci-ubuntu2204-node20:26.2.4-testing-add-python3.11.9-to-ci-image` which adds Python 3.11.9 support.

## Background

- **Ticket**: [CLO-171 - Upgrade IT to run with Node 20](https://linear.app/dash0/issue/CLO-171/upgrade-it-to-run-with-node-20)
- **Utils PR**: https://github.com/lumigo-io/utils/pull/647

We're testing this new CI image across multiple repositories before making it the default in the lumigo-orb. The image adds Python 3.11.9 which was previously missing and causing builds to fail.

## Changes

- Override `docker_image` for `lumigo-orb/prep-it-resources` and `lumigo-orb/integration-test-parallel` jobs

## Test plan

- [ ] CI passes with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)