### PR TITLE
chore: verify CI with node20 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,3 +109,4 @@ jobs:
       - lumigo-orb/checkout_code
       - lumigo-orb/checkout_utils
       - run: . venv/bin/activate && pip install -r requirements.txt && ./scripts/bd_to_prod.sh
+


### PR DESCRIPTION
## Summary
- Dummy change to verify CI passes with the updated lumigo-orb node20 default image
- This PR can be closed after CI verification

## Test plan
- [ ] CI pipeline passes with the orb's default `lumigo/ci-ubuntu2204-node20:latest` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)